### PR TITLE
Feature/finalexpansions

### DIFF
--- a/ft_printf/libft/ft_strexpand.c
+++ b/ft_printf/libft/ft_strexpand.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/09/13 16:04:59 by lgutter        #+#    #+#                */
-/*   Updated: 2019/09/27 13:37:00 by ivan-tey      ########   odam.nl         */
+/*   Updated: 2020/02/04 15:23:17 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ void	ft_strexpand(char **source, const char *addition)
 	{
 		*source = ft_strdup(addition);
 	}
-	else
+	else if (addition != NULL)
 	{
 		*source = ft_strjoin(*source, addition);
 		free(temp);

--- a/srcs/ft_expand_variable.c
+++ b/srcs/ft_expand_variable.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/21 12:13:49 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 16:51:16 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 16:06:45 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,22 +33,25 @@ static int		ft_expand_dollar(t_env *env_list, char **string)
 	char	*ret;
 	size_t	len;
 
-	key = (*string) + 1;
+	key = ft_strchr(*string, '$') + 1;
+	ret = ft_strndup(*string, (key - *string - 1));
 	len = ft_env_str_len(key);
 	key = ft_strndup(key, len);
-	if (key == NULL)
+	if (ret == NULL || key == NULL)
 	{
+		free(ret);
+		free(key);
 		return (ERR_MALLOCFAIL);
 	}
-	ret = ft_getenv(env_list, key);
-	if (ret == NULL)
-	{
-		free(key);
-		return (ERR_INVALID_EXP);
-	}
+	ft_strexpand(&ret, ft_getenv(env_list, key));
 	free(key);
+	if (ret == NULL)
+		return (ERR_MALLOCFAIL);
+	ft_strexpand(&ret, ft_strchr(*string, '$') + len + 1);
+	if (ret == NULL)
+		return (ERR_MALLOCFAIL);
 	free(*string);
-	*string = ft_strdup(ret);
+	*string = ret;
 	return (0);
 }
 
@@ -57,26 +60,22 @@ int				ft_expand_variable(t_env *env_list, char **string)
 	char	*temp;
 	int		ret;
 
-	ret = ERR_INVALID_EXP;
+	ret = 0;
 	temp = *string;
-	if (temp[0] == '~')
+	if (temp[0] == '~' && (temp[1] == '\0' || temp[1] == '/'))
 	{
-		ret = 0;
-		if (temp[1] == '\0' || (temp[1] == '/' && temp[2] == '\0'))
-		{
-			temp = ft_strdup(ft_getenv(env_list, "HOME"));
-			if (temp != NULL)
-			{
-				free(*string);
-				*string = temp;
-			}
-			else
-				ret = ERR_MALLOCFAIL;
-		}
+		temp = ft_strjoin(ft_getenv(env_list, "HOME"), (temp + 1));
+		if (temp == NULL)
+			return (ERR_MALLOCFAIL);
+		free(*string);
+		*string = temp;
 	}
-	else if (temp[0] == '$')
+	while (ft_strchr(*string, '$') != NULL &&
+			ft_strchr(*string, '$') != &(*string)[ft_strlen(*string) - 1])
 	{
-		return (ft_expand_dollar(env_list, string));
+		ret = ft_expand_dollar(env_list, string);
+		if (ret != 0)
+			break;
 	}
 	return (ret);
 }

--- a/srcs/ft_free_command.c
+++ b/srcs/ft_free_command.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 14:10:47 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 15:26:27 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 13:59:32 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,9 +14,6 @@
 
 int			ft_free_command(t_command *command)
 {
-	size_t	index;
-
-	index = 0;
 	free(command->input);
 	command->input = NULL;
 	ft_free_str_array(command->argv);

--- a/srcs/ft_handle_expansions.c
+++ b/srcs/ft_handle_expansions.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/21 12:00:42 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 15:16:58 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 14:46:02 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,17 @@
 
 int		ft_handle_expansions(t_env *env_list, char **argv)
 {
-	int index;
-	int ret;
-	int final_ret;
+	int		index;
+	int		ret;
+	int		final_ret;
+	char	*var_start;
 
 	index = 1;
 	final_ret = 0;
 	while (argv[index] != NULL)
 	{
-		if (argv[index][0] == '$' || argv[index][0] == '~')
+		var_start = ft_strchr(argv[index], '$');
+		if ( var_start != NULL || argv[index][0] =='~')
 		{
 			ret = ft_expand_variable(env_list, &(argv[index]));
 			if (ret != 0)

--- a/tests/srcs/ft_handle_expansions_tests.c
+++ b/tests/srcs/ft_handle_expansions_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 15:33:58 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/28 16:56:17 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 16:08:13 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,5 +43,5 @@ Test(unit_ft_handle_expansions, basic_error_expand_invalid_env_key, .init = redi
 	ret = ft_handle_expansions(env, argv);
 	fflush(stderr);
 	cr_assert_stderr_eq_str("-ish: Environment key not found\n");
-	cr_assert_eq(ret, ERR_INVALID_EXP);
+	cr_assert_eq(ret, 0);
 }


### PR DESCRIPTION
expansions are now handled correctly.
~ is expanded at beginning of arg, $KEY is expanded everywhere.
a $ at the end of an arg is left in place.

No tests yet due to time constraints.

closes #13 