### PR TITLE
Hotfix/freeenvlistcontent

### DIFF
--- a/ft_printf/libft/ft_memccpy.c
+++ b/ft_printf/libft/ft_memccpy.c
@@ -5,8 +5,8 @@
 /*                                                     +:+                    */
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2019/01/25 21:31:21 by lgutter       #+#    #+#                 */
-/*   Updated: 2019/01/25 21:31:46 by lgutter       ########   odam.nl         */
+/*   Created: 2019/01/25 21:31:21 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/04 17:37:31 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,6 @@ void	*ft_memccpy(void *dst, const void *src, int delim, size_t len)
 	{
 		output[index] = input[index];
 		index++;
-		return ((void *)&dst[index]);
+		return ((void *)&output[index]);
 	}
 }

--- a/ft_printf/libft/ft_memexpand.c
+++ b/ft_printf/libft/ft_memexpand.c
@@ -5,8 +5,8 @@
 /*                                                     +:+                    */
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2019/02/15 13:29:30 by lgutter       #+#    #+#                 */
-/*   Updated: 2019/02/15 13:29:31 by lgutter       ########   odam.nl         */
+/*   Created: 2019/02/15 13:29:30 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/04 18:11:55 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,11 +20,12 @@ void	ft_memexpand(void **src, size_t *size1, const void *add, size_t size2)
 	if (*src == NULL)
 	{
 		*src = ft_memdup(add, size2);
+		*size1 += size2;
 	}
-	else
+	else if (add != NULL && size2 != 0)
 	{
 		*src = ft_memjoin(*src, *size1, add, size2);
 		free(temp);
+		*size1 += size2;
 	}
-	*size1 += size2;
 }

--- a/ft_printf/libft/get_next_line.c
+++ b/ft_printf/libft/get_next_line.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/02/14 14:37:52 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/15 18:46:32 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 18:17:35 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ static int		list_add_new(int fd, t_cache **start, char *buf,
 {
 	t_cache *new;
 
-	if (buf == NULL || (ssize_t)ft_strlenc(buf, '\n', i) >= i)
+	if (buf == NULL || (ssize_t)ft_strlenc(buf, '\n', i) >= (i - 1))
 		return (0);
 	new = (t_cache *)malloc(sizeof(t_cache) * 1);
 	if (new == NULL)

--- a/incl/builtins.h
+++ b/incl/builtins.h
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 10:00:17 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 14:49:39 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 17:55:41 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ int		ft_echo_builtin(t_env *env_list, t_command *command);
 **	and print "exit" right before doing so.
 **	It will use the most recent status code as exit code.
 */
-int		ft_exit_builtin(t_env *env_list, t_command *command);
+void	ft_exit_builtin(t_env *env_list, t_command *command);
 
 /*
 **	The builtin command setenv will attempt to set the key-value pair

--- a/srcs/ft_exit_builtin.c
+++ b/srcs/ft_exit_builtin.c
@@ -6,13 +6,13 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 10:35:22 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 10:41:57 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 17:55:53 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 
-int		ft_exit_builtin(t_env *env_list, t_command *command)
+void	ft_exit_builtin(t_env *env_list, t_command *command)
 {
 	int		exit_code;
 	char	*env_status;

--- a/srcs/ft_free_env_list.c
+++ b/srcs/ft_free_env_list.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 14:01:30 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 14:03:31 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 17:31:21 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,10 @@ int		ft_free_env_list(t_env *env_list)
 	{
 		previous = current;
 		current = current->next;
+		free(previous->key);
+		previous->key = NULL;
+		free(previous->value);
+		previous->value = NULL;
 		free(previous);
 		previous = NULL;
 	}

--- a/srcs/ft_handle_command.c
+++ b/srcs/ft_handle_command.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/15 19:19:30 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 15:04:39 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 17:57:45 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ static int	execute_builtin(t_env *env_list, t_command *command)
 	else if (ft_strcmp(command->argv[0], "echo") == 0)
 		ret = ft_echo_builtin(env_list, command);
 	else if (ft_strcmp(command->argv[0], "exit") == 0)
-		ret = ft_exit_builtin(env_list, command);
+		ft_exit_builtin(env_list, command);
 	else if (ft_strcmp(command->argv[0], "env") == 0)
 		ret = ft_env_builtin(env_list, command);
 	else if (ft_strcmp(command->argv[0], "setenv") == 0)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/06 15:16:07 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 16:50:08 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 17:47:41 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,9 @@ static int	input_loop(t_env *env_start)
 		if (get_next_line(0, &(command.input)) == 0)
 		{
 			ret = ft_getstatus(env_start);
-			return (ret == 0 ? -1 : ret);
+			ft_free_env_list(env_start);
+			free(command.input);
+			return (ret);
 		}
 		if (command.input[0] != '\0')
 		{


### PR DESCRIPTION
I was not freeing the content of the list, just the structs.

Other issues (mostly leaks) I fixed while I was at it:

- when the user presses ctrl+d, everything is now correctly freed.
- converted the exit builtin to be a void function.
- fixed an indexing mistake in GNL, causing a "leak" when using exit (was keeping a static linked list when not needed)
- two small fixes in libft functions.