### PR TITLE
Hotfix/tabsandexpansionincommand

### DIFF
--- a/ft_printf/libft/ft_strsplit_t_s.c
+++ b/ft_printf/libft/ft_strsplit_t_s.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/01/21 18:29:22 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 20:10:03 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 21:17:40 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,12 +54,11 @@ static char		*ft_writeword_t_s(char const *string, size_t index)
 	len = index;
 	while (ft_is_tab_space(string[len]) == 0 && string[len] != '\0')
 		len++;
-	ret = (char *)malloc(sizeof(char) * ((len - index) + 1));
-	if (!ret)
+	ret = (char *)ft_memalloc(sizeof(char) * len + 1);
+	if (ret == NULL)
 		return (NULL);
-	ret[len - index] = '\0';
 	len = 0;
-	while (ft_is_tab_space(string[len]) == 0 && string[index] != '\0')
+	while (ft_is_tab_space(string[index]) == 0 && string[index] != '\0')
 	{
 		ret[len] = string[index];
 		index++;
@@ -79,8 +78,8 @@ char			**ft_strsplit_t_s(char const *string)
 	index = 0;
 	wordcount = ft_wordcount_t_s(string);
 	wordindex = 0;
-	ret = (char **)malloc(sizeof(char *) * (wordcount + 1));
-	if (!ret)
+	ret = (char **)ft_memalloc(sizeof(char *) * (wordcount + 1));
+	if (ret == NULL)
 		return (NULL);
 	ret[wordcount] = NULL;
 	while (string[index] != '\0' && wordindex < wordcount)

--- a/ft_printf/libft/ft_strsplit_t_s.c
+++ b/ft_printf/libft/ft_strsplit_t_s.c
@@ -1,0 +1,97 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_strsplit_t_s.c                                  :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2019/01/21 18:29:22 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/04 20:10:03 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+static int		ft_is_tab_space(int c)
+{
+	if (c == ' ' || c == '\t')
+	{
+		return (1);
+	}
+		return (0);
+}
+
+static size_t	ft_wordcount_t_s(char const *string)
+{
+	size_t	index;
+	size_t	wordcount;
+
+	index = 0;
+	wordcount = 0;
+	while (string[index] != '\0')
+	{
+		while (ft_is_tab_space(string[index]) == 1)
+		{
+			index++;
+		}
+		if (string[index] != '\0')
+		{
+			wordcount++;
+		}
+		while (ft_is_tab_space(string[index]) == 0 && string[index] != '\0')
+		{
+			index++;
+		}
+	}
+	return (wordcount);
+}
+
+static char		*ft_writeword_t_s(char const *string, size_t index)
+{
+	size_t	len;
+	char	*ret;
+
+	len = index;
+	while (ft_is_tab_space(string[len]) == 0 && string[len] != '\0')
+		len++;
+	ret = (char *)malloc(sizeof(char) * ((len - index) + 1));
+	if (!ret)
+		return (NULL);
+	ret[len - index] = '\0';
+	len = 0;
+	while (ft_is_tab_space(string[len]) == 0 && string[index] != '\0')
+	{
+		ret[len] = string[index];
+		index++;
+		len++;
+	}
+	ret[len] = '\0';
+	return (ret);
+}
+
+char			**ft_strsplit_t_s(char const *string)
+{
+	char	**ret;
+	size_t	index;
+	size_t	wordcount;
+	size_t	wordindex;
+
+	index = 0;
+	wordcount = ft_wordcount_t_s(string);
+	wordindex = 0;
+	ret = (char **)malloc(sizeof(char *) * (wordcount + 1));
+	if (!ret)
+		return (NULL);
+	ret[wordcount] = NULL;
+	while (string[index] != '\0' && wordindex < wordcount)
+	{
+		while (ft_is_tab_space(string[index]) == 1)
+			index++;
+		if (string[index] != '\0')
+			ret[wordindex] = ft_writeword_t_s(string, index);
+		wordindex++;
+		while (ft_is_tab_space(string[index]) == 0 && string[index] != '\0')
+			index++;
+	}
+	return (ret);
+}

--- a/ft_printf/libft/libft.h
+++ b/ft_printf/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/01/10 17:29:34 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 14:03:52 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 19:18:57 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,6 +78,7 @@ char				*ft_strsub(char const *string, unsigned int start,
 char				*ft_strjoin(char const *string1, char const *string2);
 char				*ft_strtrim(char const *str);
 char				**ft_strsplit(char const *string, char delim);
+char				**ft_strsplit_t_s(char const *string);
 char				*ft_itoa(int integer);
 void				ft_putchar(char character);
 void				ft_putstr(char const *string);

--- a/ft_printf/libft/libftsources
+++ b/ft_printf/libft/libftsources
@@ -44,6 +44,7 @@ ft_strsub \
 ft_strjoin \
 ft_strtrim \
 ft_strsplit \
+ft_strsplit_t_s \
 ft_itoa \
 ft_putchar \
 ft_putstr \

--- a/srcs/ft_handle_expansions.c
+++ b/srcs/ft_handle_expansions.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/21 12:00:42 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 14:46:02 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 19:08:31 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ int		ft_handle_expansions(t_env *env_list, char **argv)
 	int		final_ret;
 	char	*var_start;
 
-	index = 1;
+	index = 0;
 	final_ret = 0;
 	while (argv[index] != NULL)
 	{

--- a/srcs/ft_print_error.c
+++ b/srcs/ft_print_error.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/10 17:31:22 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/28 16:56:45 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 19:09:53 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ static const char	*errid_to_str(t_errid errid)
 		[ERR_ENVNOTFOUND]	= "Environment key not found",
 		[ERR_EMPTYENV]		= "Environment is empty",
 		[ERR_INVALID_EXP]	= "Invalid expansion",
-		[ERR_EXECVE_FAILED]	= "Failure in execve",
+		[ERR_EXECVE_FAILED]	= "Unable to execute",
 		[ERR_FORK_FAILED]	= "Failure in fork",
 		[ERR_CMD_NOT_FOUND]	= "Command not found",
 	};

--- a/srcs/ft_split_command.c
+++ b/srcs/ft_split_command.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/15 19:29:22 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 16:47:41 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 21:19:28 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ int			ft_split_command(t_env *env_list, t_command *command)
 	temp = ft_strtrim(command->input);
 	if (temp[0] != '\0')
 	{
-		command->argv = ft_strsplit(temp, ' ');
+		command->argv = ft_strsplit_t_s(temp);
 		if (command->argv != NULL)
 		{
 			command->envp = ft_convert_env_to_envp(env_list);


### PR DESCRIPTION
fixed expansions not working in argv[0].
I assumed expansions in the command itself were not valid.
Fixed that, and made error when execution fails a bit clearer.

arguments can now also be seperated by tabs,
thanks to a new implementation of ft_strsplit. (hardcoded to tabs and spaces)
This is to properly and reliably handle arguments.

closes #23 
closes #24