### PR TITLE
fixed cd printing path when not needed

### DIFF
--- a/srcs/ft_cd_builtin.c
+++ b/srcs/ft_cd_builtin.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 10:08:52 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 15:35:08 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 21:54:28 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,20 @@ static char	*find_path(t_env *env_list, t_command *command)
 
 	path = NULL;
 	if (command->argc < 2)
+	{
 		path = ft_getenv(env_list, "HOME");
+		if (path == NULL)
+			ft_dprintf(2, "cd: HOME not set\n");
+	}
 	else if (command->argc == 2)
 	{
 		if (command->argv[1][0] == '-' && command->argv[1][1] == '\0')
 		{
 			path = ft_getenv(env_list, "OLDPWD");
 			if (path == NULL)
-				path = ft_getenv(env_list, "HOME");
+				ft_dprintf(2, "cd: OLDPWD not set\n");
+			else
+				ft_printf("%s\n", path);
 		}
 		else
 			path = command->argv[1];
@@ -36,12 +42,15 @@ static char	*find_path(t_env *env_list, t_command *command)
 int		ft_cd_builtin(t_env *env_list, t_command *command)
 {
 	char	*path;
+	char	*old_path;
 	int		ret;
 
 	ret = 0;
 	path = find_path(env_list, command);
 	if (path == NULL)
-		return (ft_print_error(ERR_MALLOCFAIL));
+		return (ERR_ENVNOTFOUND);
+	old_path = NULL;
+	old_path = getcwd(old_path, 0);
 	ret = chdir(path);
 	if (ret != 0)
 	{
@@ -50,12 +59,12 @@ int		ft_cd_builtin(t_env *env_list, t_command *command)
 	}
 	else
 	{
-		ft_printf("%s\n", path);
-		ft_setenv(env_list, "OLDPWD", ft_getenv(env_list, "PWD"), 'y');
+		ft_setenv(env_list, "OLDPWD", old_path, 'y');
 		path = NULL;
-		path = getcwd(path, 1024);
+		path = getcwd(path, 0);
 		ft_setenv(env_list, "PWD", path, 'y');
 		free(path);
 	}
+	free(old_path);
 	return (ret);
 }

--- a/srcs/ft_cd_builtin.c
+++ b/srcs/ft_cd_builtin.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 10:08:52 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 21:54:28 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 22:04:47 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,8 +49,7 @@ int		ft_cd_builtin(t_env *env_list, t_command *command)
 	path = find_path(env_list, command);
 	if (path == NULL)
 		return (ERR_ENVNOTFOUND);
-	old_path = NULL;
-	old_path = getcwd(old_path, 0);
+	old_path = getcwd(NULL, 0);
 	ret = chdir(path);
 	if (ret != 0)
 	{
@@ -60,8 +59,7 @@ int		ft_cd_builtin(t_env *env_list, t_command *command)
 	else
 	{
 		ft_setenv(env_list, "OLDPWD", old_path, 'y');
-		path = NULL;
-		path = getcwd(path, 0);
+		path = getcwd(NULL, 0);
 		ft_setenv(env_list, "PWD", path, 'y');
 		free(path);
 	}

--- a/srcs/ft_getenv.c
+++ b/srcs/ft_getenv.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/13 15:49:17 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/13 16:58:05 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 21:37:31 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,5 @@ char	*ft_getenv(t_env *env, const char *key)
 		}
 		current = current->next;
 	}
-	ft_print_error(ERR_ENVNOTFOUND);
 	return (NULL);
 }

--- a/tests/srcs/ft_getenv_tests.c
+++ b/tests/srcs/ft_getenv_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/13 17:00:36 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/13 17:13:49 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 22:20:10 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,8 +38,10 @@ Test(unit_ft_getenv, mandatory_basic_get_from_empty_list, .init = redirect_std_e
 	t_env *list = NULL;
 
 	value = ft_getenv(list, "MINISHELL_TEST_GET_ENV");
+	cr_assert_eq(NULL, value);
+	ft_dprintf(2, "-");
 	fflush(stderr);
-	cr_assert_stderr_eq_str("-ish: Environment key not found\n");
+	cr_assert_stderr_eq_str("-");
 }
 
 Test(unit_ft_getenv, mandatory_basic_get_valid_value_from_system_list, .init = redirect_std_err)

--- a/tests/srcs/ft_getstatus_tests.c
+++ b/tests/srcs/ft_getstatus_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/15 12:20:03 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/27 10:56:46 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 22:18:38 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,9 +38,10 @@ Test(unit_ft_getstatus, mandatory_basic_get_status_from_empty_list, .init = redi
 	t_env *list = NULL;
 
 	value = ft_getstatus(list);
-	fflush(stderr);
 	cr_assert_eq(value, ERR_ENVNOTFOUND);
-	cr_assert_stderr_eq_str("-ish: Environment key not found\n");
+	ft_dprintf(2, "-");
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
 }
 
 Test(unit_ft_getstatus, mandatory_basic_get_status_from_system_list, .init = redirect_std_err)

--- a/tests/srcs/ft_handle_expansions_tests.c
+++ b/tests/srcs/ft_handle_expansions_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 15:33:58 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 16:08:13 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/04 22:19:22 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,8 @@ Test(unit_ft_handle_expansions, basic_error_expand_invalid_env_key, .init = redi
 	int ret;
 
 	ret = ft_handle_expansions(env, argv);
+	ft_dprintf(2, "-");
 	fflush(stderr);
-	cr_assert_stderr_eq_str("-ish: Environment key not found\n");
+	cr_assert_stderr_eq_str("-");
 	cr_assert_eq(ret, 0);
 }


### PR DESCRIPTION
cd will now only print the path it's trying to change to,
if the argument is -.
Also removed the error print from getenv since it wasn't really useful anywhere.

closes #25 
closes #22 
closes #21 