### PR TITLE
Enhance/improvetestcoverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ install:
     - sudo touch /tmp/printf
 before_script:
     - make test CV=1
+    - make MAIN=tests/srcs/empty_env_dup_sys_env_test.c CV=1 NAME=emptyenvtest
     - env
 script:
     - ./tests/minitest --verbose
+    - env -i ./tests/minitest --verbose
+    - env -i ./emptyenvtest
 after_success:
     - make gcov
     - bash <(curl -s https://codecov.io/bash) -X gcov

--- a/ft_printf/libft/ft_free_str_array.c
+++ b/ft_printf/libft/ft_free_str_array.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 14:12:44 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 15:25:29 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 11:40:00 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,12 +17,15 @@ size_t	ft_free_str_array(char **array)
 	size_t index;
 
 	index = 0;
-	while (array[index] != NULL)
+	if (array != NULL)
 	{
-		free(array[index]);
-		array[index] = NULL;
-		index++;
+		while (array[index] != NULL)
+		{
+			free(array[index]);
+			array[index] = NULL;
+			index++;
+		}
+		free(array);
 	}
-	free(array);
 	return (index);
 }

--- a/ft_printf/libft/ft_strjoin.c
+++ b/ft_printf/libft/ft_strjoin.c
@@ -5,8 +5,8 @@
 /*                                                     +:+                    */
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2019/01/18 16:52:17 by lgutter       #+#    #+#                 */
-/*   Updated: 2019/01/19 12:24:15 by lgutter       ########   odam.nl         */
+/*   Created: 2019/01/18 16:52:17 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 08:39:53 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,8 +40,15 @@ char			*ft_strjoin(char const *string1, char const *string2)
 		return (NULL);
 	}
 	ret[in + dex] = '\0';
-	in = 0;
-	in = ft_strjoin_internal(ret, string1, in);
-	ft_strjoin_internal(ret, string2, in);
+	if (string1 == NULL && string2 != NULL)
+		ret = ft_strncpy(ret, string2, dex);
+	else if (string1 != NULL && string2 == NULL)
+		ret = ft_strncpy(ret, string1, in);
+	else if (string1 != NULL && string2 != NULL)
+	{
+		in = 0;
+		in = ft_strjoin_internal(ret, string1, in);
+		ft_strjoin_internal(ret, string2, in);
+	}
 	return (ret);
 }

--- a/ft_printf/libft/ft_strlen.c
+++ b/ft_printf/libft/ft_strlen.c
@@ -5,8 +5,8 @@
 /*                                                     +:+                    */
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2019/01/16 15:36:46 by lgutter       #+#    #+#                 */
-/*   Updated: 2019/01/16 15:36:47 by lgutter       ########   odam.nl         */
+/*   Created: 2019/01/16 15:36:46 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 08:34:01 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ size_t	ft_strlen(const char *string)
 	size_t len;
 
 	len = 0;
+	if (string == NULL)
+		return (0);
 	while (string[len] != '\0')
 		len++;
 	return (len);

--- a/srcs/ft_expand_variable.c
+++ b/srcs/ft_expand_variable.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/21 12:13:49 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 16:06:45 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/06 19:26:49 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,13 +58,15 @@ static int		ft_expand_dollar(t_env *env_list, char **string)
 int				ft_expand_variable(t_env *env_list, char **string)
 {
 	char	*temp;
+	char	*value;
 	int		ret;
 
 	ret = 0;
 	temp = *string;
 	if (temp[0] == '~' && (temp[1] == '\0' || temp[1] == '/'))
 	{
-		temp = ft_strjoin(ft_getenv(env_list, "HOME"), (temp + 1));
+		value = ft_getenv(env_list, "HOME");
+		temp = ft_strjoin(value, (temp + 1));
 		if (temp == NULL)
 			return (ERR_MALLOCFAIL);
 		free(*string);

--- a/srcs/ft_setenv_builtin.c
+++ b/srcs/ft_setenv_builtin.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 10:48:05 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 14:14:15 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 12:39:29 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ static int	check_key(char *key)
 	if (ft_isalpha(key[0]) != 1)
 	{
 		ft_dprintf(2, "setenv: Variable name must begin with a letter.\n");
-		return (-1);
+		return (1);
 	}
 	else
 	{
@@ -30,24 +30,12 @@ static int	check_key(char *key)
 			{
 				ft_dprintf(2, "setenv: Variable name must only contain ");
 				ft_dprintf(2, "alphanumerical characters.\n");
-				return (-1);
+				return (1);
 			}
 			index++;
 		}
 	}
 	return (0);
-}
-
-static void	update_envp(t_env *env_list, t_command *command)
-{
-	char **new_envp;
-
-	new_envp = ft_convert_env_to_envp(env_list);
-	if (new_envp != NULL)
-	{
-		ft_free_str_array(command->envp);
-		command->envp = new_envp;
-	}
 }
 
 int			ft_setenv_builtin(t_env *env_list, t_command *command)
@@ -69,9 +57,8 @@ int			ft_setenv_builtin(t_env *env_list, t_command *command)
 		if (ret == 0)
 		{
 			ret = ft_setenv(env_list, command->argv[1], value, 'y');
-			if (ret == 0)
-				update_envp(env_list, command);
 		}
 	}
+	ft_setstatus(env_list, ret);
 	return (ret);
 }

--- a/srcs/ft_unsetenv.c
+++ b/srcs/ft_unsetenv.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/13 20:08:17 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/13 21:06:13 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 13:15:06 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ int			ft_unsetenv(t_env *env, const char *key)
 		previous = previous->next;
 	}
 	if (previous == NULL)
-		return (ft_print_error(ERR_ENVNOTFOUND));
+		return (ERR_ENVNOTFOUND);
 	current = previous->next;
 	free(current->key);
 	free(current->value);

--- a/srcs/ft_unsetenv_builtin.c
+++ b/srcs/ft_unsetenv_builtin.c
@@ -6,60 +6,32 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/31 11:28:32 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 15:31:42 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 13:06:26 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 
-static int	update_envp(t_command *command)
-{
-	size_t index;
-	size_t unset_index;
-	size_t len;
-
-	index = 0;
-	unset_index = 0;
-	while (command->envp[index] != NULL)
-	{
-		len = ft_strlen(command->envp[index]);
-		len = ft_strlenc(command->envp[index], '=', len);
-		if (ft_strncmp(command->envp[index], command->argv[1], len) == 0)
-		{
-			unset_index = index;
-			free(command->envp[unset_index]);
-			break ;
-		}
-		index++;
-	}
-	if (command->envp[index] == NULL)
-		return (1);
-	while (command->envp[index + 1] != NULL)
-		index++;
-	command->envp[unset_index] = command->envp[index];
-	command->envp[index] = NULL;
-	return (0);
-}
-
 int			ft_unsetenv_builtin(t_env *env_list, t_command *command)
 {
-	int	ret;
 	int	index;
+	int	ret;
 
-	ret = 1;
 	index = 1;
 	if (command->argc < 2)
 	{
 		ft_dprintf(2, "unsetenv: Too few arguments.\n");
-		return (ret);
+		ret = 1;
 	}
-	while (index < command->argc && command->argv[index] != NULL)
+	else
 	{
-		if (ft_unsetenv(env_list, command->argv[index]) == 0)
+		while (index < command->argc && command->argv[index] != NULL)
 		{
-			update_envp(command);
+			ft_unsetenv(env_list, command->argv[index]);
+			index++;
 		}
-		index++;
+		ret = 0;
 	}
-	return (0);
+	ft_setstatus(env_list, ret);
+	return (ret);
 }

--- a/tests/srcs/empty_env_dup_sys_env_test.c
+++ b/tests/srcs/empty_env_dup_sys_env_test.c
@@ -1,0 +1,63 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   empty_env_dup_sys_env_test.c                       :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/06 19:32:02 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/06 20:01:41 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/*
+**	This seperate test is needed because criterion is not able to
+**	call a function after making the system env empty.
+**	this main can be compiled with the following command:
+**	"make MAIN=tests/srcs/empty_env_dup_sys_env_test.c CV=1 NAME=emptyenvtest",
+**	and called with "env -i ./emptyenvtest".
+**	that way, it is run with a completely empty environment.
+*/
+
+int main(void)
+{
+	t_env		*start_env;
+	t_env		*current;
+	t_errid		errid = 0;
+	char		*realpwd;
+	extern char **environ;
+
+	start_env = ft_dup_sys_env(&errid);
+	current = start_env;
+	if (environ[0] != NULL)
+	{
+		dprintf(2, "Please run this test with env -i:\nenv -i ./emptyenvtest\n");
+		return (1);
+	}
+	if (current == NULL || errid != 0)
+	{
+		dprintf(2, "ft_dup_sys_env did not exit correctly.\n");
+		dprintf(2, "\treturn value:\t%p\n\terrid value:\t%hhu\n", current, errid);
+		return (-1);
+	}
+	if (strcmp(current->key, "PWD") != 0)
+	{
+		dprintf(2, "incorrect key.\n\texpected:\tPWD\n\tactual:\t\t%s\n", current->key);
+		return (-1);
+	}
+	realpwd = getcwd(NULL, 0);
+	if (strcmp(current->value, realpwd) != 0)
+	{
+		dprintf(2, "incorrect value.\n\texpected:\t%s\n\tactual:\t\t%s\n", realpwd, current->value);
+		free(realpwd);
+		return (-1);
+	}
+	printf("Succesful empty env test!\n");
+	free(realpwd);
+	return (0);
+}

--- a/tests/srcs/ft_cd_builtin_tests.c
+++ b/tests/srcs/ft_cd_builtin_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 10:04:02 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 11:14:39 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ Test(unit_ft_cd_builtin, basic_mandatory_cd_to_root, .init = redirect_std_err)
 
 	env->key = strdup("PWD");
 	env->value = getcwd(NULL, 0);
+	env->next = NULL;
 	command.input = strdup("cd /");
 	command.argv = ft_strsplit("cd /", ' ');
 	command.argc = 2;
@@ -54,6 +55,7 @@ Test(unit_ft_cd_builtin, basic_mandatory_cd_to_home, .init = redirect_std_err)
 
 	env->key = strdup("HOME");
 	env->value = strdup("/");
+	env->next = NULL;
 	command.input = strdup("cd");
 	command.argv = ft_strsplit("cd", ' ');
 	command.argc = 1;
@@ -75,6 +77,7 @@ Test(unit_ft_cd_builtin, basic_mandatory_cd_to_oldpwd, .init = redirect_std_out)
 
 	env->key = strdup("OLDPWD");
 	env->value = strdup("/");
+	env->next = NULL;
 	command.input = strdup("cd -");
 	command.argv = ft_strsplit("cd -", ' ');
 	command.argc = 2;
@@ -96,6 +99,7 @@ Test(unit_ft_cd_builtin, basic_mandatory_error_cd_no_oldpwd, .init = redirect_st
 
 	env->key = strdup("PWD");
 	env->value = getcwd(NULL, 0);
+	env->next = NULL;
 	command.input = strdup("cd -");
 	command.argv = ft_strsplit("cd -", ' ');
 	command.argc = 2;
@@ -117,6 +121,7 @@ Test(unit_ft_cd_builtin, basic_mandatory_error_cd_no_home, .init = redirect_std_
 
 	env->key = strdup("PWD");
 	env->value = getcwd(NULL, 0);
+	env->next = NULL;
 	command.input = strdup("cd");
 	command.argv = ft_strsplit("cd", ' ');
 	command.argc = 1;
@@ -138,6 +143,7 @@ Test(unit_ft_cd_builtin, basic_mandatory_error_cd_not_valid, .init = redirect_st
 
 	env->key = strdup("PWD");
 	env->value = getcwd(NULL, 0);
+	env->next = NULL;
 	command.input = strdup("cd foobar");
 	command.argv = ft_strsplit("cd foobar", ' ');
 	command.argc = 2;

--- a/tests/srcs/ft_cd_builtin_tests.c
+++ b/tests/srcs/ft_cd_builtin_tests.c
@@ -1,0 +1,151 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_cd_builtin_tests.c                              :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 10:04:02 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <criterion/assert.h>
+#include <stdio.h>
+#include "builtins.h"
+
+static void redirect_std_out(void)
+{
+	cr_redirect_stdout();
+}
+
+static void redirect_std_err(void)
+{
+	cr_redirect_stderr();
+}
+
+Test(unit_ft_cd_builtin, basic_mandatory_cd_to_root, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("PWD");
+	env->value = getcwd(NULL, 0);
+	command.input = strdup("cd /");
+	command.argv = ft_strsplit("cd /", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	dprintf(2, "-");
+	ret = ft_cd_builtin(env, &command);
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(getcwd(NULL, 0), "/");
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
+}
+
+Test(unit_ft_cd_builtin, basic_mandatory_cd_to_home, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("HOME");
+	env->value = strdup("/");
+	command.input = strdup("cd");
+	command.argv = ft_strsplit("cd", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	dprintf(2, "-");
+	ret = ft_cd_builtin(env, &command);
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(getcwd(NULL, 0), "/");
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
+}
+
+Test(unit_ft_cd_builtin, basic_mandatory_cd_to_oldpwd, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+	char		*firstdir = getcwd(NULL, 0);
+
+	env->key = strdup("OLDPWD");
+	env->value = strdup("/");
+	command.input = strdup("cd -");
+	command.argv = ft_strsplit("cd -", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	ret = ft_cd_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("/\n");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(getcwd(NULL, 0), "/");
+	cr_assert_str_eq(firstdir, env->value);
+}
+
+Test(unit_ft_cd_builtin, basic_mandatory_error_cd_no_oldpwd, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+	char		*firstdir = getcwd(NULL, 0);
+
+	env->key = strdup("PWD");
+	env->value = getcwd(NULL, 0);
+	command.input = strdup("cd -");
+	command.argv = ft_strsplit("cd -", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	ret = ft_cd_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("cd: OLDPWD not set\n");
+	cr_assert_eq(ret, ERR_ENVNOTFOUND);
+	cr_assert_str_eq(firstdir, getcwd(NULL, 0));
+	cr_assert_str_eq(firstdir, env->value);
+}
+
+Test(unit_ft_cd_builtin, basic_mandatory_error_cd_no_home, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+	char		*firstdir = getcwd(NULL, 0);
+
+	env->key = strdup("PWD");
+	env->value = getcwd(NULL, 0);
+	command.input = strdup("cd");
+	command.argv = ft_strsplit("cd", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	ret = ft_cd_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("cd: HOME not set\n");
+	cr_assert_eq(ret, ERR_ENVNOTFOUND);
+	cr_assert_str_eq(firstdir, getcwd(NULL, 0));
+	cr_assert_str_eq(firstdir, env->value);
+}
+
+Test(unit_ft_cd_builtin, basic_mandatory_error_cd_not_valid, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+	char		*firstdir = getcwd(NULL, 0);
+
+	env->key = strdup("PWD");
+	env->value = getcwd(NULL, 0);
+	command.input = strdup("cd foobar");
+	command.argv = ft_strsplit("cd foobar", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	ret = ft_cd_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("cd: no such file or directory: foobar\n");
+	cr_assert_neq(ret, 0);
+	cr_assert_str_eq(firstdir, getcwd(NULL, 0));
+	cr_assert_str_eq(firstdir, env->value);
+}

--- a/tests/srcs/ft_echo_builtin_tests.c
+++ b/tests/srcs/ft_echo_builtin_tests.c
@@ -1,0 +1,132 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_echo_builtin_tests.c                            :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 11:57:22 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <criterion/assert.h>
+#include <stdio.h>
+#include "builtins.h"
+
+static void redirect_std_out(void)
+{
+	cr_redirect_stdout();
+}
+
+Test(unit_ft_echo_builtin, basic_mandatory_empty_echo, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("echo");
+	command.argv = ft_strsplit("echo", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	ret = ft_echo_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("\n");
+	cr_assert_eq(ret, 0);
+	cr_assert_eq(env->next, NULL);
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+}
+
+Test(unit_ft_echo_builtin, basic_mandatory_simple_echo, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("echo foo");
+	command.argv = ft_strsplit("echo foo", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	ret = ft_echo_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("foo\n");
+	cr_assert_eq(ret, 0);
+	cr_assert_eq(env->next, NULL);
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+}
+
+Test(unit_ft_echo_builtin, basic_mandatory_simple_multiple_echo, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("echo foo bar baz");
+	command.argv = ft_strsplit("echo foo bar baz", ' ');
+	command.argc = 4;
+	command.envp = NULL;
+	ret = ft_echo_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("foo bar baz\n");
+	cr_assert_eq(ret, 0);
+	cr_assert_eq(env->next, NULL);
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+}
+
+Test(unit_ft_echo_builtin, basic_mandatory_error_argc_too_small, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("echo foo bar baz");
+	command.argv = ft_strsplit("echo foo bar baz", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	ret = ft_echo_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("foo\n");
+	cr_assert_eq(ret, 1);
+	cr_assert_eq(env->next, NULL);
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+}
+
+Test(unit_ft_echo_builtin, basic_mandatory_error_argc_too_big, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("echo foo bar baz");
+	command.argv = ft_strsplit("echo foo bar baz", ' ');
+	command.argc = 42;
+	command.envp = NULL;
+	ret = ft_echo_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("foo bar baz\n");
+	cr_assert_eq(ret, 1);
+	cr_assert_eq(env->next, NULL);
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+}

--- a/tests/srcs/ft_env_builtin_tests.c
+++ b/tests/srcs/ft_env_builtin_tests.c
@@ -1,0 +1,86 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_env_builtin_tests.c                             :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 12:12:45 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <criterion/assert.h>
+#include <stdio.h>
+#include "builtins.h"
+
+static void redirect_std_out(void)
+{
+	cr_redirect_stdout();
+}
+
+Test(unit_ft_env_builtin, basic_mandatory_env_one_line, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("env");
+	command.argv = ft_strsplit("env", ' ');
+	command.argc = 1;
+	command.envp = ft_strsplit("FOO=BAR", ' ');
+	ret = ft_env_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("FOO=BAR\n");
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(ret, 0);
+}
+
+Test(unit_ft_env_builtin, basic_mandatory_env_3_lines, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("env");
+	command.argv = ft_strsplit("env", ' ');
+	command.argc = 1;
+	command.envp = ft_strsplit("FOO=BAR BAZ=OOF CODAM=42", ' ');
+	ret = ft_env_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("FOO=BAR\nBAZ=OOF\nCODAM=42\n");
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(ret, 0);
+}
+
+Test(unit_ft_env_builtin, basic_mandatory_error_NULL_envp, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("");
+	env->value = strdup("");
+	env->next = NULL;
+	command.input = strdup("env");
+	command.argv = ft_strsplit("env", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	ret = ft_env_builtin(env, &command);
+	printf("-");
+	fflush(stdout);
+	cr_assert_stdout_eq_str("-");
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+	cr_assert_eq(ret, 1);
+}

--- a/tests/srcs/ft_exit_builtin_tests.c
+++ b/tests/srcs/ft_exit_builtin_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 11:44:11 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 12:10:34 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ Test(unit_ft_exit_builtin, basic_mandatory_exit_42, .init = redirect_std_out)
 	command.argv = ft_strsplit("exit", ' ');
 	command.argc = 1;
 	command.envp = NULL;
+	command.path = NULL;
 	pid = fork();
 	if (pid == 0)
 	{
@@ -71,6 +72,7 @@ Test(unit_ft_exit_builtin, basic_mandatory_error_no_exit_code, .init = redirect_
 	command.argv = ft_strsplit("exit", ' ');
 	command.argc = 1;
 	command.envp = NULL;
+	command.path = NULL;
 	pid = fork();
 	if (pid == 0)
 	{
@@ -103,6 +105,7 @@ Test(unit_ft_exit_builtin, undefined_error_nothing_defined, .init = redirect_std
 	command.argv = NULL;
 	command.argc = 0;
 	command.envp = NULL;
+	command.path = NULL;
 	pid = fork();
 	if (pid == 0)
 	{

--- a/tests/srcs/ft_exit_builtin_tests.c
+++ b/tests/srcs/ft_exit_builtin_tests.c
@@ -1,0 +1,124 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_exit_builtin_tests.c                            :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 11:44:11 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <criterion/assert.h>
+#include <stdio.h>
+#include "builtins.h"
+
+static void redirect_std_out(void)
+{
+	cr_redirect_stdout();
+}
+
+Test(unit_ft_exit_builtin, basic_mandatory_exit_42, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	int			stat_loc = -1;
+	pid_t	pid;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup(STATUS_CODE_KEY);
+	env->value = strdup("42");
+	env->next = NULL;
+	command.input = strdup("exit");
+	command.argv = ft_strsplit("exit", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	pid = fork();
+	if (pid == 0)
+	{
+		ft_exit_builtin(env, &command);
+		exit(-42);
+	}
+	else if (pid > 0)
+	{
+		waitpid(pid, &stat_loc, 0);
+		ret = WEXITSTATUS(stat_loc);
+		cr_assert_eq(ret, 42);
+		fflush(stdout);
+		cr_assert_stdout_eq_str("exit\n");
+	}
+	else
+	{
+		cr_assert_fail("fork failed\n");
+	}
+}
+
+Test(unit_ft_exit_builtin, basic_mandatory_error_no_exit_code, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	int			stat_loc = -1;
+	pid_t	pid;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("exit");
+	command.argv = ft_strsplit("exit", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	pid = fork();
+	if (pid == 0)
+	{
+		ft_exit_builtin(env, &command);
+		exit(-42);
+	}
+	else if (pid > 0)
+	{
+		waitpid(pid, &stat_loc, 0);
+		ret = WEXITSTATUS(stat_loc);
+		cr_assert_eq(ret, 0);
+		fflush(stdout);
+		cr_assert_stdout_eq_str("exit\n");
+	}
+	else
+	{
+		cr_assert_fail("fork failed\n");
+	}
+}
+
+Test(unit_ft_exit_builtin, undefined_error_nothing_defined, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	int			stat_loc = -1;
+	pid_t	pid;
+	t_env		*env = NULL;
+
+	command.input = NULL;
+	command.argv = NULL;
+	command.argc = 0;
+	command.envp = NULL;
+	pid = fork();
+	if (pid == 0)
+	{
+		ft_exit_builtin(env, &command);
+		exit(-42);
+	}
+	else if (pid > 0)
+	{
+		waitpid(pid, &stat_loc, 0);
+		ret = WEXITSTATUS(stat_loc);
+		cr_assert_eq(ret, 0);
+		fflush(stdout);
+		cr_assert_stdout_eq_str("exit\n");
+	}
+	else
+	{
+		cr_assert_fail("fork failed\n");
+	}
+}

--- a/tests/srcs/ft_expand_variable_tests.c
+++ b/tests/srcs/ft_expand_variable_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 15:28:21 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/22 15:33:13 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/06 19:23:38 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,24 +18,28 @@
 
 Test(unit_ft_expand_variable, basic_mandatory_expand_tilde)
 {
-	t_errid errid;
-	t_env *env = ft_dup_sys_env(&errid);
+	t_env *env = (t_env *)malloc(sizeof(t_env) * 1);
 	char *test_string = strdup("~");
 	int ret;
 
+	env->key = strdup("HOME");
+	env->value = strdup("/home/criteriontest");
+	env->next = NULL;
 	ret = ft_expand_variable(env, &test_string);
 	cr_assert_eq(ret, 0);
-	cr_assert_str_eq(test_string, getenv("HOME"));
+	cr_assert_str_eq(test_string, "/home/criteriontest");
 }
 
 Test(unit_ft_expand_variable, basic_mandatory_expand_HOME)
 {
-	t_errid errid;
-	t_env *env = ft_dup_sys_env(&errid);
-	char *test_string = strdup("$HOME");
+	t_env *env = (t_env *)malloc(sizeof(t_env) * 1);
+	char *test_string = strdup("$FOO");
 	int ret;
 
+	env->key = strdup("FOO");
+	env->value = strdup("Barcriteriontest");
+	env->next = NULL;
 	ret = ft_expand_variable(env, &test_string);
 	cr_assert_eq(ret, 0);
-	cr_assert_str_eq(test_string, getenv("HOME"));
+	cr_assert_str_eq(test_string, "Barcriteriontest");
 }

--- a/tests/srcs/ft_handle_command_tests.c
+++ b/tests/srcs/ft_handle_command_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/27 10:58:45 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 09:13:06 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 09:17:23 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -183,7 +183,8 @@ Test(unit_ft_handle_command, basic_mandatory_error_command_error, .init = redire
 	command.input = strdup("ls ~/fooarg1 bararg2");
 	ret = ft_split_command(env, &command);
 	ret = ft_handle_command(env, command);
-	cr_assert_neq(ret, 0);
+	cr_assert_eq(ret, 0);
+	cr_assert_neq(NULL, ft_getenv(env, STATUS_CODE_KEY));
 }
 
 Test(unit_ft_handle_command, basic_mandatory_error_command_not_found, .init = redirect_std_err)

--- a/tests/srcs/ft_handle_command_tests.c
+++ b/tests/srcs/ft_handle_command_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/27 10:58:45 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 09:17:23 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 09:24:11 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,24 @@ Test(unit_ft_handle_command, basic_mandatory_handle_simple_command, .init = redi
 	fflush(stdout);
 	cr_assert_eq(ret, 0);
 	cr_assert_stdout_eq_str("arg1 arg2 arg3\n");
+}
+
+Test(unit_ft_handle_command, basic_mandatory_handle_nonexec_command, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("PATH");
+	env->value = strdup("/tmp:/bin:/usr/bin");
+	env->next = NULL;
+
+	command.input = strdup("printf arg1");
+	ret = ft_split_command(env, &command);
+	ret = ft_handle_command(env, command);
+	fflush(stdout);
+	cr_assert_eq(ret, 0);
+	cr_assert_stdout_eq_str("arg1");
 }
 
 Test(unit_ft_handle_command, basic_mandatory_handle_dollar_expansion_in_arg, .init = redirect_std_out)

--- a/tests/srcs/ft_handle_command_tests.c
+++ b/tests/srcs/ft_handle_command_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/27 10:58:45 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 12:28:20 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 13:08:56 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -182,8 +182,8 @@ Test(unit_ft_handle_command, basic_mandatory_handle_builtin_unsetenv, .init = re
 	fflush(stdout);
 	cr_assert_eq(ret, 0);
 	cr_assert_eq(env->next, NULL);
-	cr_assert_str_eq(env->key, "");
-	cr_assert_str_eq(env->value, "");
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
 	cr_assert_stdout_eq_str("-");
 }
 

--- a/tests/srcs/ft_handle_command_tests.c
+++ b/tests/srcs/ft_handle_command_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/27 10:58:45 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 09:00:47 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 09:13:06 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -178,7 +178,7 @@ Test(unit_ft_handle_command, basic_mandatory_error_command_error, .init = redire
 	env->next = env_path;
 	env_path->key = strdup("PATH");
 	env_path->value = strdup("/bin:/usr/bin");
-	env->next = NULL;
+	env_path->next = NULL;
 
 	command.input = strdup("ls ~/fooarg1 bararg2");
 	ret = ft_split_command(env, &command);
@@ -198,7 +198,7 @@ Test(unit_ft_handle_command, basic_mandatory_error_command_not_found, .init = re
 	env->next = env_path;
 	env_path->key = strdup("PATH");
 	env_path->value = strdup("/usr/bin");
-	env->next = NULL;
+	env_path->next = NULL;
 
 	command.input = strdup("foobartest arg1 arg2");
 	command.path = NULL;

--- a/tests/srcs/ft_handle_command_tests.c
+++ b/tests/srcs/ft_handle_command_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/27 10:58:45 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/07 09:24:11 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 12:28:20 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -158,6 +158,9 @@ Test(unit_ft_handle_command, basic_mandatory_handle_builtin_setenv, .init = redi
 	env = env->next;
 	cr_assert_str_eq(env->key, "FOO");
 	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
 	cr_assert_eq(env->next, NULL);
 	cr_assert_stdout_eq_str("-");
 }

--- a/tests/srcs/ft_handle_expansions_tests.c
+++ b/tests/srcs/ft_handle_expansions_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 15:33:58 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 22:19:22 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/06 19:24:59 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,19 +23,21 @@ static void redirect_std_err(void)
 
 Test(unit_ft_handle_expansions, basic_mandatory_expand_only_tilde)
 {
-		t_errid errid;
-	t_env *env = ft_dup_sys_env(&errid);
+	t_env *env = (t_env *)malloc(sizeof(t_env) * 1);
 	char **argv = ft_strsplit("hello ~ test", ' ');
 	int ret;
 
+	env->key = strdup("HOME");
+	env->value = strdup("/home/criteriontest");
+	env->next = NULL;
 	ret = ft_handle_expansions(env, argv);
 	cr_assert_eq(ret, 0);
-	cr_assert_str_eq(argv[1], getenv("HOME"));
+	cr_assert_str_eq(argv[1], "/home/criteriontest");
 }
 
 Test(unit_ft_handle_expansions, basic_error_expand_invalid_env_key, .init = redirect_std_err)
 {
-		t_errid errid;
+	t_errid errid;
 	t_env *env = ft_dup_sys_env(&errid);
 	char **argv = ft_strsplit("hello $doesnotexist test", ' ');
 	int ret;

--- a/tests/srcs/ft_handle_expansions_tests.c
+++ b/tests/srcs/ft_handle_expansions_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 15:33:58 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/06 19:24:59 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 08:45:59 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,20 @@ Test(unit_ft_handle_expansions, basic_mandatory_expand_only_tilde)
 	ret = ft_handle_expansions(env, argv);
 	cr_assert_eq(ret, 0);
 	cr_assert_str_eq(argv[1], "/home/criteriontest");
+}
+
+Test(unit_ft_handle_expansions, basic_mandatory_expand_tilde_at_start)
+{
+	t_env *env = (t_env *)malloc(sizeof(t_env) * 1);
+	char **argv = ft_strsplit("hello ~/test", ' ');
+	int ret;
+
+	env->key = strdup("HOME");
+	env->value = strdup("/home/criteriontest");
+	env->next = NULL;
+	ret = ft_handle_expansions(env, argv);
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(argv[1], "/home/criteriontest/test");
 }
 
 Test(unit_ft_handle_expansions, basic_error_expand_invalid_env_key, .init = redirect_std_err)

--- a/tests/srcs/ft_setenv_builtin_tests.c
+++ b/tests/srcs/ft_setenv_builtin_tests.c
@@ -1,0 +1,182 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_setenv_builtin_tests.c                          :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 12:40:36 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <criterion/assert.h>
+#include <stdio.h>
+#include "builtins.h"
+
+static void redirect_std_out(void)
+{
+	cr_redirect_stdout();
+}
+
+static void redirect_std_err(void)
+{
+	cr_redirect_stderr();
+}
+
+Test(unit_ft_setenv_builtin, basic_mandatory_set_new_env, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("setenv CODAM BAZ");
+	command.argv = ft_strsplit("setenv CODAM BAZ", ' ');
+	command.argc = 3;
+	command.envp = NULL;
+	printf("-");
+	ret = ft_setenv_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("-");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, "CODAM");
+	cr_assert_str_eq(env->value, "BAZ");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_setenv_builtin, basic_mandatory_replace_env, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("setenv FOO BAZ");
+	command.argv = ft_strsplit("setenv FOO BAZ", ' ');
+	command.argc = 3;
+	command.envp = NULL;
+	printf("-");
+	ret = ft_setenv_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("-");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAZ");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_setenv_builtin, basic_mandatory_no_args, .init = redirect_std_out)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("setenv");
+	command.argv = ft_strsplit("setenv", ' ');
+	command.argc = 1;
+	command.envp = ft_strsplit("FOO=BAR FOR=BAO", ' ');
+	ret = ft_setenv_builtin(env, &command);
+	fflush(stdout);
+	cr_assert_stdout_eq_str("FOO=BAR\nFOR=BAO\n");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_setenv_builtin, basic_mandatory_error_too_many_args, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("setenv FOO BAR BAZ");
+	command.argv = ft_strsplit("setenv FOO BAR BAZ", ' ');
+	command.argc = 4;
+	command.envp = NULL;
+	ret = ft_setenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("setenv: Too many arguments.\n");
+	cr_assert_eq(ret, 1);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_setenv_builtin, basic_mandatory_error_invalid_key_digit_start, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("setenv 3FOO BAR");
+	command.argv = ft_strsplit("setenv 3FOO BAR", ' ');
+	command.argc = 3;
+	command.envp = NULL;
+	ret = ft_setenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("setenv: Variable name must begin with a letter.\n");
+	cr_assert_eq(ret, 1);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_setenv_builtin, basic_mandatory_error_invalid_key_invalid_char, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("setenv FO*O BAR");
+	command.argv = ft_strsplit("setenv FO*O BAR", ' ');
+	command.argc = 3;
+	command.envp = NULL;
+	ret = ft_setenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("setenv: Variable name must only contain alphanumerical characters.\n");
+	cr_assert_eq(ret, 1);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+	cr_assert_eq(env->next, NULL);
+}

--- a/tests/srcs/ft_unsetenv_builtin_tests.c
+++ b/tests/srcs/ft_unsetenv_builtin_tests.c
@@ -1,0 +1,156 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_unsetenv_builtin_tests.c                        :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2020/02/07 09:29:48 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 13:17:44 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <criterion/assert.h>
+#include <stdio.h>
+#include "builtins.h"
+
+static void redirect_std_err(void)
+{
+	cr_redirect_stderr();
+}
+
+Test(unit_ft_unsetenv_builtin, basic_mandatory_unsetenv_simple, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+	t_env		*env2 = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = env2;
+	env2->key = strdup("BAZ");
+	env2->value = strdup("OOF");
+	env2->next = NULL;
+	command.input = strdup("unsetenv BAZ");
+	command.argv = ft_strsplit("unsetenv BAZ", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	dprintf(2, "-");
+	ret = ft_unsetenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_unsetenv_builtin, basic_mandatory_unsetenv_first, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+	t_env		*env2 = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = env2;
+	env2->key = strdup("BAZ");
+	env2->value = strdup("OOF");
+	env2->next = NULL;
+	command.input = strdup("unsetenv FOO");
+	command.argv = ft_strsplit("unsetenv FOO", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	dprintf(2, "-");
+	ret = ft_unsetenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, "BAZ");
+	cr_assert_str_eq(env->value, "OOF");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_unsetenv_builtin, basic_mandatory_unsetenv_first_and_only, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("unsetenv FOO");
+	command.argv = ft_strsplit("unsetenv FOO", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	dprintf(2, "-");
+	ret = ft_unsetenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_unsetenv_builtin, basic_mandatory_unsetenv_fake_keys, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("unsetenv BLAH");
+	command.argv = ft_strsplit("unsetenv BERP", ' ');
+	command.argc = 2;
+	command.envp = NULL;
+	dprintf(2, "-");
+	ret = ft_unsetenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("-");
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "0");
+	cr_assert_eq(env->next, NULL);
+}
+
+Test(unit_ft_unsetenv_builtin, basic_mandatory_error_no_args, .init = redirect_std_err)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("FOO");
+	env->value = strdup("BAR");
+	env->next = NULL;
+	command.input = strdup("unsetenv");
+	command.argv = ft_strsplit("unsetenv", ' ');
+	command.argc = 1;
+	command.envp = NULL;
+	ret = ft_unsetenv_builtin(env, &command);
+	fflush(stderr);
+	cr_assert_stderr_eq_str("unsetenv: Too few arguments.\n");
+	cr_assert_eq(ret, 1);
+	cr_assert_str_eq(env->key, "FOO");
+	cr_assert_str_eq(env->value, "BAR");
+	env = env->next;
+	cr_assert_str_eq(env->key, STATUS_CODE_KEY);
+	cr_assert_str_eq(env->value, "1");
+	cr_assert_eq(env->next, NULL);
+}

--- a/tests/srcs/ft_unsetenv_tests.c
+++ b/tests/srcs/ft_unsetenv_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/13 20:25:34 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/13 21:07:56 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 13:16:03 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,8 +116,9 @@ Test(unit_ft_unsetenv, mandatory_error_unset_non_existent_element, .init = redir
 	third->next = NULL;
 	ret = ft_unsetenv(env, "BAR");
 	cr_assert_eq(ret, ERR_ENVNOTFOUND);
+	dprintf(2, "-");
 	fflush(stderr);
-	cr_assert_stderr_eq_str("-ish: Environment key not found\n");
+	cr_assert_stderr_eq_str("-");
 }
 
 Test(unit_ft_unsetenv, mandatory_error_unset_NULL_list, .init = redirect_std_err)

--- a/tests/srcs/testsrcs
+++ b/tests/srcs/testsrcs
@@ -16,3 +16,4 @@ ft_is_builtin_tests\
 ft_cd_builtin_tests\
 ft_exit_builtin_tests\
 ft_echo_builtin_tests\
+ft_env_builtin_tests\

--- a/tests/srcs/testsrcs
+++ b/tests/srcs/testsrcs
@@ -15,3 +15,4 @@ ft_find_executable_tests\
 ft_is_builtin_tests\
 ft_cd_builtin_tests\
 ft_exit_builtin_tests\
+ft_echo_builtin_tests\

--- a/tests/srcs/testsrcs
+++ b/tests/srcs/testsrcs
@@ -13,3 +13,4 @@ ft_handle_command_tests\
 ft_split_command_tests\
 ft_find_executable_tests\
 ft_is_builtin_tests\
+ft_cd_builtin_tests\

--- a/tests/srcs/testsrcs
+++ b/tests/srcs/testsrcs
@@ -18,3 +18,4 @@ ft_exit_builtin_tests\
 ft_echo_builtin_tests\
 ft_env_builtin_tests\
 ft_setenv_builtin_tests\
+ft_unsetenv_builtin_tests\

--- a/tests/srcs/testsrcs
+++ b/tests/srcs/testsrcs
@@ -14,3 +14,4 @@ ft_split_command_tests\
 ft_find_executable_tests\
 ft_is_builtin_tests\
 ft_cd_builtin_tests\
+ft_exit_builtin_tests\

--- a/tests/srcs/testsrcs
+++ b/tests/srcs/testsrcs
@@ -17,3 +17,4 @@ ft_cd_builtin_tests\
 ft_exit_builtin_tests\
 ft_echo_builtin_tests\
 ft_env_builtin_tests\
+ft_setenv_builtin_tests\


### PR DESCRIPTION
This PR contains improvements to the test coverage.

- expansions tests no longer depend on system env.
- added test outside criterion to handle empty env: Since I can't get criterion to spawn a test with a COMPLETELY empty env, I wrote this test externally and integrated it into travis.
- added builtin handling tests and command error test to handle_command_tests


closes #30 

