### PR TITLE
Hotfix/singlecharacterignored

### DIFF
--- a/ft_printf/libft/ft_strtrim.c
+++ b/ft_printf/libft/ft_strtrim.c
@@ -5,8 +5,8 @@
 /*                                                     +:+                    */
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2019/01/19 14:47:49 by lgutter       #+#    #+#                 */
-/*   Updated: 2019/01/19 14:47:50 by lgutter       ########   odam.nl         */
+/*   Created: 2019/01/19 14:47:49 by lgutter        #+#    #+#                */
+/*   Updated: 2020/02/07 14:32:50 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,18 +17,23 @@ char	*ft_strtrim(char const *str)
 	size_t	end;
 	size_t	index;
 	char	*ret;
+	int		empty;
 
 	index = 0;
+	empty = 1;
 	while (str[index] == '\n' || str[index] == '\t' || str[index] == ' ')
 		index++;
-	end = (ft_strlen(str));
+	end = ft_strlen(str);
 	if (end > 0)
 		end--;
 	while ((str[end] == '\n' || str[end] == '\t' || str[end] == ' ') && end > 0)
 		end--;
-	if (end == 0)
-		index = (end + 1);
-	ret = ft_strsub(str, (unsigned int)index, (end - index) + 1);
+	if (end == 0 && (str[end] == '\n' || str[end] == '\t' || str[end] == ' '))
+	{
+		index = 0;
+		empty = 0;
+	}
+	ret = ft_strsub(str, (unsigned int)index, (end - index) + empty);
 	if (!ret)
 		return (NULL);
 	return (ret);

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/06 15:16:37 by lgutter        #+#    #+#                */
-/*   Updated: 2020/01/31 13:53:35 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 14:05:48 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@
 /*
 **	the prompt to be displayed when input is expected.
 */
-# define SHELL_PROMPT "\033[38;5;75m -ish » \033[0;00m"
+# define SHELL_PROMPT "\033[38;5;75m-ish » \033[0;00m"
 
 /*
 **	the key for the status code in the environment.

--- a/tests/srcs/ft_split_command_tests.c
+++ b/tests/srcs/ft_split_command_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/27 10:58:45 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/04 13:04:48 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/07 14:32:19 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,27 @@ Test(unit_ft_split_command, basic_mandatory_split_simple_command)
 	cr_assert_str_eq(command.argv[1], "arg1");
 	cr_assert_str_eq(command.argv[2], "arg2");
 	cr_assert_str_eq(command.argv[3], "arg3");
+	cr_assert_str_eq(command.envp[0], "TESTENVKEY=TESTENVVALUE");
+	cr_assert_eq(command.envp[1], NULL);
+	cr_assert_eq(command.path, NULL);
+}
+
+Test(unit_ft_split_command, basic_mandatory_split_single_char_command)
+{
+	t_command	command;
+	int			ret;
+	t_env		*env = (t_env *)malloc(sizeof(t_env) * 1);
+
+	env->key = strdup("TESTENVKEY");
+	env->value = strdup("TESTENVVALUE");
+	env->next = NULL;
+
+	command.input = strdup("t");
+	command.path = NULL;
+	ret = ft_split_command(env, &command);
+	cr_assert_eq(ret, 0);
+	cr_assert_eq(command.argc, 1);
+	cr_assert_str_eq(command.argv[0], "t");
 	cr_assert_str_eq(command.envp[0], "TESTENVKEY=TESTENVVALUE");
 	cr_assert_eq(command.envp[1], NULL);
 	cr_assert_eq(command.path, NULL);


### PR DESCRIPTION
if strtrim gets only a single char, without whitespace, it broke.
it would return an empty string.

also added a test to catch this.