### PR TITLE
fix: fixed infinite loop in variable expansion

### DIFF
--- a/tests/srcs/ft_expand_variable_tests.c
+++ b/tests/srcs/ft_expand_variable_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/01/22 15:28:21 by lgutter        #+#    #+#                */
-/*   Updated: 2020/02/06 19:23:38 by lgutter       ########   odam.nl         */
+/*   Updated: 2020/02/15 13:32:15 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,4 +42,32 @@ Test(unit_ft_expand_variable, basic_mandatory_expand_HOME)
 	ret = ft_expand_variable(env, &test_string);
 	cr_assert_eq(ret, 0);
 	cr_assert_str_eq(test_string, "Barcriteriontest");
+}
+
+Test(unit_ft_expand_variable, basic_mandatory_no_key)
+{
+	t_env *env = (t_env *)malloc(sizeof(t_env) * 1);
+	char *test_string = strdup("$.FOO");
+	int ret;
+
+	env->key = strdup("FOO");
+	env->value = strdup("Barcriteriontest");
+	env->next = NULL;
+	ret = ft_expand_variable(env, &test_string);
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(test_string, "$.FOO");
+}
+
+Test(unit_ft_expand_variable, basic_mandatory_loop_key, .timeout = 2)
+{
+	t_env *env = (t_env *)malloc(sizeof(t_env) * 1);
+	char *test_string = strdup("$FOO");
+	int ret;
+
+	env->key = strdup("FOO");
+	env->value = strdup("$FOO");
+	env->next = NULL;
+	ret = ft_expand_variable(env, &test_string);
+	cr_assert_eq(ret, 0);
+	cr_assert_str_eq(test_string, "$FOO");
 }


### PR DESCRIPTION
when FOO=$FOO is in the env, it would create an infinite loop when expanding.
Now it keeps track of where in the string we are, so it will only try to expand any index once.
Also improved handling of invalid keys like $. and $-.
Since this is not something we handle, it is clearer to just leave it in place.

closes #34 